### PR TITLE
Don't panic on nil value, instead represent as `nil`.

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -144,7 +144,7 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 	seen[v] = true
 	defer delete(seen, v)
 
-	if (v.Kind() == reflect.Ptr || v.Kind() == reflect.Map || v.Kind() == reflect.Chan || v.Kind() == reflect.Slice || v.Kind() == reflect.Func || v.Kind() == reflect.Interface) && v.IsNil() {
+	if v.Kind() == reflect.Invalid || (v.Kind() == reflect.Ptr || v.Kind() == reflect.Map || v.Kind() == reflect.Chan || v.Kind() == reflect.Slice || v.Kind() == reflect.Func || v.Kind() == reflect.Interface) && v.IsNil() {
 		fmt.Fprint(p.w, "nil")
 		return
 	}

--- a/repr_test.go
+++ b/repr_test.go
@@ -87,6 +87,18 @@ func TestReprPrivateField(t *testing.T) {
 	assert.Equal(t, `repr.privateTestStruct{a: "hello"}`, String(s))
 }
 
+func TestReprNilAlone(t *testing.T) {
+	var err error
+	s := String(err)
+	assert.Equal(t, "nil", s)
+}
+
+func TestReprNilInsideArray(t *testing.T) {
+	arr := []*privateTestStruct{{"hello"}, nil}
+	s := String(arr)
+	assert.Equal(t, "[]*repr.privateTestStruct{&repr.privateTestStruct{a: \"hello\"}, nil}", s)
+}
+
 type Enum int
 
 func (e Enum) String() string {


### PR DESCRIPTION
Related to issue #2

Also, added an extra test that was already passing before this patch (`TestReprNilInsideArray`), but left it in for extra coverage.