### PR TITLE
Add go.mod and time.Time human readable representation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/alecthomas/repr
+
+go 1.15


### PR DESCRIPTION
It always bugs me how time.Time gets printed ... so here is a fix.

If a struct is time.Time it gets printed as time.Date(...) which
hides the private fields of time.Time.

If you have other suggestions or don't like it. Let me know :-)