### PR TITLE
fix ordering of non-string keyed maps

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -212,7 +212,7 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 		}
 		keys := v.MapKeys()
 		sort.Slice(keys, func(i, j int) bool {
-			return keys[i].String() < keys[j].String()
+			return fmt.Sprint(keys[i]) < fmt.Sprint(keys[j])
 		})
 		for i, k := range keys {
 			kv := v.MapIndex(k)

--- a/repr_test.go
+++ b/repr_test.go
@@ -60,6 +60,13 @@ func TestReprMap(t *testing.T) {
 	}
 }
 
+func TestReprIntMap(t *testing.T) {
+	m := map[int]string{3: "b", 1: "a", 5: "c"}
+	for i := 0; i < 1000; i++ {
+		equal(t, "map[int]string{1: \"a\", 3: \"b\", 5: \"c\"}", String(m))
+	}
+}
+
 func TestReprStructWithIndent(t *testing.T) {
 	pi := new(int)
 	*pi = 13


### PR DESCRIPTION
`reflect.Value.String()` only prints the value of `string` types. For other types it just prints the type information.

```go
// String returns the string v's underlying value, as a string.
// String is a special case because of Go's String method convention.
// Unlike the other getters, it does not panic if v's Kind is not String.
// Instead, it returns a string of the form "<T value>" where T is v's type.
// The fmt package treats Values specially. It does not call their String
// method implicitly but instead prints the concrete values they hold.
func (v Value) String() string {
	switch k := v.kind(); k {
	case Invalid:
		return "<invalid Value>"
	case String:
		return *(*string)(v.ptr)
	}
	// If you call String on a reflect.Value of other type, it's better to
	// print something than to panic. Useful in debugging.
	return "<" + v.Type().String() + " Value>"
}
```