### PR TITLE
Fix zero-length slice field with omitempty

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -181,9 +181,6 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 	ni := p.nextIndent(indent)
 	switch v.Kind() {
 	case reflect.Slice, reflect.Array:
-		if p.omitEmpty && v.Len() == 0 {
-			return
-		}
 		fmt.Fprintf(p.w, "%s{", v.Type())
 		if v.Len() == 0 {
 			fmt.Fprint(p.w, "}")

--- a/repr_test.go
+++ b/repr_test.go
@@ -125,6 +125,32 @@ func TestReprNilInsideArray(t *testing.T) {
 	equal(t, "[]*repr.privateTestStruct{{a: \"hello\"}, nil}", s)
 }
 
+func TestReprEmptySlice(t *testing.T) {
+	a := []int{}
+	s := String(a)
+	equal(t, "[]int{}", s)
+}
+
+func TestReprNilSlice(t *testing.T) {
+	var a []int
+	s := String(a)
+	equal(t, "nil", s)
+}
+
+type intSliceStruct struct{ f []int }
+
+func TestReprEmptySliceStruct(t *testing.T) {
+	a := intSliceStruct{f: []int{}}
+	s := String(a)
+	equal(t, "repr.intSliceStruct{f: []int{}}", s)
+}
+
+func TestReprNilSliceStruct(t *testing.T) {
+	var a intSliceStruct
+	s := String(a)
+	equal(t, "repr.intSliceStruct{}", s)
+}
+
 type Enum int
 
 func (e Enum) String() string {


### PR DESCRIPTION
There were two problems here, the combination of which caused incorrect
output.  The first is that we should really only check omitempty on a
struct field; a slice alone should ignore it.  For example
`repr.String([]int{})` should return `[]int{}`, not `""` (and likewise
for `[]int(nil)`).  The second is that the check in the slice code was
checking `len(s) == 0`, whereas the check in the struct-field code was
checking `s == nil`.  Either would be reasonable, but having both means
they need to match!  This generated output like
`repr.intSliceStruct{f: }` which is a syntax error.

Anyway, to fix this I just removed the check in slice.  We still omit
nil correctly, we just handle it at the point of the struct field.