### PR TITLE
Add IgnorePrivate option to skip private fields

### DIFF
--- a/repr_test.go
+++ b/repr_test.go
@@ -107,6 +107,23 @@ func TestReprPrivateField(t *testing.T) {
 	equal(t, `repr.privateTestStruct{a: "hello"}`, String(s))
 }
 
+type mixedTestStruct struct {
+	A  string
+	b  string
+	C  string
+	_D string
+}
+
+func TestReprPrivateMixed(t *testing.T) {
+	s := mixedTestStruct{"hello", "world", "goodbye", "cruel world"}
+	equal(t, `repr.mixedTestStruct{A: "hello", b: "world", C: "goodbye", _D: "cruel world"}`, String(s))
+}
+
+func TestReprPrivateMixedIgnorePrivate(t *testing.T) {
+	s := mixedTestStruct{"hello", "world", "goodbye", "cruel world"}
+	equal(t, `repr.mixedTestStruct{A: "hello", C: "goodbye"}`, String(s, IgnorePrivate()))
+}
+
 func TestReprNilAlone(t *testing.T) {
 	var err error
 	s := String(err)


### PR DESCRIPTION
This patch adds IgnorePrivate option to prevent private fields in a
structure from being displayed. It takes care to remove trailing comma
if a private field ends the structure.

Tests have been updated to validate this new option.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>