### PR TITLE
Mask certain keys

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -74,6 +74,13 @@ func IgnoreGoStringer() Option { return func(o *Printer) { o.ignoreGoStringer = 
 // IgnorePrivate disables private field members from output.
 func IgnorePrivate() Option { return func(o *Printer) { o.ignorePrivate = true } }
 
+// MaskKeys removes certain keys from output.
+func MaskKeys(keys ...string) Option {
+	return func(o *Printer) {
+		o.excludeKeys = keys
+	}
+}
+
 // ScalarLiterals forces the use of literals for scalars, rather than a string representation if available.
 //
 // For example, `time.Hour` will be printed as `time.Duration(3600000000000)` rather than `time.Duration(1h0m0s)`.
@@ -102,6 +109,7 @@ type Printer struct {
 	exclude           map[reflect.Type]bool
 	w                 io.Writer
 	useLiterals       bool
+	excludeKeys       []string
 }
 
 // New creates a new Printer on w with the given Options.
@@ -271,6 +279,25 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 				}
 				previous = true
 				fmt.Fprintf(p.w, "%s%s: ", ni, t.Name)
+
+				// ignore specific Keye
+				if p.excludeKeys != nil {
+					skip := false
+					for _, k := range p.excludeKeys {
+						if k == t.Name {
+							skip = true
+							break
+						}
+					}
+					if skip {
+						fmt.Fprint(p.w, "***")
+						if p.indent != "" {
+							fmt.Fprintf(p.w, ",\n")
+						}
+						continue
+					}
+				}
+
 				p.reprValue(seen, f, ni, true, t.Type == anyType)
 
 				// if private fields should be ignored, look up if a public

--- a/repr_test.go
+++ b/repr_test.go
@@ -148,6 +148,16 @@ func TestReprPrivateMixedIgnorePrivate(t *testing.T) {
 	equal(t, `repr.mixedTestStruct{A: "hello", C: "goodbye"}`, String(s, IgnorePrivate()))
 }
 
+func TestReprExcludeKeys(t *testing.T) {
+	s := mixedTestStruct{"hello", "world", "goodbye", "cruel world"}
+	equal(t, `repr.mixedTestStruct{A: "hello", C: ***}`, String(s, MaskKeys("C"), IgnorePrivate()))
+}
+
+func TestReprExcludeKeys2(t *testing.T) {
+	s := mixedTestStruct{"hello", "world", "goodbye", "cruel world"}
+	equal(t, `repr.mixedTestStruct{A: "hello", b: ***, C: ***, _D: ***}`, String(s, MaskKeys("C", "b", "_D")))
+}
+
 func TestReprNilAlone(t *testing.T) {
 	var err error
 	s := String(err)


### PR DESCRIPTION
This masks certain struct keys. 

The use case was to print a `yang.Entry` from https://github.com/openconfig/goyang

Each yang.Entry / yang.Node etc can have a parent which seems to recursively cause repr.Print to go into a loop
This now works with

```golang
repr.Println(e, repr.MaskKey("Parent"))
```

Open to change the name MaskKeys / HideKeys etc.
Could also use ... as you currently use in the seen logic
