### PR TITLE
feat: Handle json.RawMessage

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -7,6 +7,7 @@ package repr
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -47,6 +48,7 @@ var (
 	goStringerType = reflect.TypeOf((*fmt.GoStringer)(nil)).Elem()
 	anyType        = reflect.TypeOf((*any)(nil)).Elem()
 
+	rawJSONType   = reflect.TypeOf(json.RawMessage{})
 	byteSliceType = reflect.TypeOf([]byte{})
 )
 
@@ -192,6 +194,11 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 		return
 	}
 	t := v.Type()
+
+	if t == rawJSONType {
+		fmt.Fprintf(p.w, "%s", v.Bytes())
+		return
+	}
 
 	if t == byteSliceType {
 		fmt.Fprintf(p.w, "[]byte(%q)", v.Bytes())

--- a/repr_test.go
+++ b/repr_test.go
@@ -2,6 +2,7 @@ package repr
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
@@ -148,6 +149,11 @@ func TestReprStructWithIndent(t *testing.T) {
 func TestReprByteArray(t *testing.T) {
 	b := []byte{1, 2, 3}
 	equal(t, "[]byte(\"\\x01\\x02\\x03\")", String(b))
+}
+
+func TestReprJSONRaw(t *testing.T) {
+	b := json.RawMessage(`["string", 1]`)
+	equal(t, "[\"string\", 1]", String(b))
 }
 
 type privateTestStruct struct {


### PR DESCRIPTION
Without special handling, json.RawMessage is rendered as []uint8 which isn't very easy to decode. Since json.RawMessage always holds JSON text, this prints it instead so you can see the value instead.