### PR TITLE
Add HideName option to printer

### DIFF
--- a/repr_test.go
+++ b/repr_test.go
@@ -278,7 +278,7 @@ func TestReprPrivateBytes(t *testing.T) {
 }
 
 func TestReprAnyNumeric(t *testing.T) {
-	var value = []any{float64(123)}
+	value := []any{float64(123)}
 	equal(t, "[]any{float64(123)}", String(value))
 }
 
@@ -292,4 +292,13 @@ func TestReprFunc(t *testing.T) {
 func TestScalarLiterals(t *testing.T) {
 	d := time.Second
 	equal(t, "time.Duration(1000000000)", String(d, ScalarLiterals()))
+}
+
+func TestHideStructFieldsByName(t *testing.T) {
+	actual := testStruct{
+		S: "str",
+		A: anotherStruct{A: []int{1}},
+	}
+	res := String(actual, HideField("A"))
+	equal(t, `repr.testStruct{S: "str"}`, res)
 }


### PR DESCRIPTION
I have run into a situation where we are using `assert` to compare some structs, however some of these structs have some fields we don't care about but the same type as one of the fields we are directly trying to compare. This means the existing `Hide` option does not work because it will exclude everything.

This PR adds a slightly alternative option `HideName` which will hide all struct fields matching that given name, i've kept it at struct names for now but it could be extended to map keys too if we so wished. Included a test similar to the existing ones, but if you want more let me know :)

