### PR TITLE
fix: prevent IsZero() panics on interface fields

### DIFF
--- a/repr.go
+++ b/repr.go
@@ -196,8 +196,16 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 	seen[v] = true
 	defer delete(seen, v)
 
-	if v.Kind() == reflect.Invalid || (v.Kind() == reflect.Ptr || v.Kind() == reflect.Map || v.Kind() == reflect.Chan || v.Kind() == reflect.Slice || v.Kind() == reflect.Func || v.Kind() == reflect.Interface) && v.IsNil() {
+	if v.Kind() == reflect.Invalid {
 		fmt.Fprint(p.w, "nil")
+		return
+	}
+	if (v.Kind() == reflect.Ptr || v.Kind() == reflect.Map || v.Kind() == reflect.Chan || v.Kind() == reflect.Slice || v.Kind() == reflect.Func || v.Kind() == reflect.Interface) && v.IsNil() {
+		if p.alwaysIncludeType || isAnyValue {
+			fmt.Fprintf(p.w, "(%s)(nil)", substAny(v.Type()))
+		} else {
+			fmt.Fprint(p.w, "nil")
+		}
 		return
 	}
 	t := v.Type()

--- a/repr.go
+++ b/repr.go
@@ -305,10 +305,26 @@ func (p *Printer) reprValue(seen map[reflect.Value]bool, v reflect.Value, indent
 					// the method call will automatically dereference the nil pointer and
 					// panic.
 					var nilPtrValueReceiver bool
-					if ft.Kind() == reflect.Pointer && f.IsNil() {
-						_, nilPtrValueReceiver = ft.Elem().MethodByName("IsZero")
+					// interfaces can hold typed nil pointers. checkF extracts the dynamic
+					// underlying value from the interface to identify if the inner value
+					// is a nil pointer.
+					checkF := f
+					if checkF.Kind() == reflect.Interface {
+						checkF = checkF.Elem()
 					}
-					if (ft.Implements(isZeroerType) && !nilPtrValueReceiver && f.CanInterface() && f.Interface().(isZeroer).IsZero()) || f.IsZero() {
+					if checkF.Kind() == reflect.Pointer && checkF.IsNil() {
+						_, nilPtrValueReceiver = checkF.Type().Elem().MethodByName("IsZero")
+					}
+					// call the value's IsZero() if possible to determine if it should be
+					// omitted. If IsZero is not implemented or can't be called, then
+					// fall back to reflect.Value.IsZero().
+					isZero := f.IsZero()
+					if ft.Implements(isZeroerType) && f.CanInterface() && !nilPtrValueReceiver {
+						if iface := f.Interface(); iface != nil {
+							isZero = iface.(isZeroer).IsZero()
+						}
+					}
+					if isZero {
 						continue
 					}
 				}

--- a/repr_test.go
+++ b/repr_test.go
@@ -86,7 +86,7 @@ func TestReprZeroSliceMapFields(t *testing.T) {
 		ZIf isZeroer
 		If  isZeroer
 	}{[]string{}, []string{"a", "b"}, map[string]string{}, map[string]string{"a": "b"}, 0, 1, "", "a", false, true, zeroTest{i: 100}, zeroTest{i: 0}, zeroTest{i: 10}, nil, nil, (*time.Time)(nil)}
-	equal(t, `struct { ZSl []string; Sl []string; ZM map[string]string; M map[string]string; ZI int; I int; ZS string; S string; ZB bool; B bool; ZC repr.zeroTest; ZC2 repr.zeroTest; C repr.zeroTest; T *time.Time; ZIf repr.isZeroer; If repr.isZeroer }{ZSl: []string{}, Sl: []string{"a", "b"}, ZM: map[string]string{}, M: map[string]string{"a": "b"}, I: 1, S: "a", B: true, ZC2: repr.zeroTest{}, C: repr.zeroTest{i: 10}, If: nil}`, String(v, OmitEmpty(false), OmitZero(true)))
+	equal(t, `struct { ZSl []string; Sl []string; ZM map[string]string; M map[string]string; ZI int; I int; ZS string; S string; ZB bool; B bool; ZC repr.zeroTest; ZC2 repr.zeroTest; C repr.zeroTest; T *time.Time; ZIf repr.isZeroer; If repr.isZeroer }{ZSl: []string{}, Sl: []string{"a", "b"}, ZM: map[string]string{}, M: map[string]string{"a": "b"}, I: 1, S: "a", B: true, ZC2: repr.zeroTest{}, C: repr.zeroTest{i: 10}, If: (*time.Time)(nil)}`, String(v, OmitEmpty(false), OmitZero(true)))
 }
 
 func TestReprStringArray(t *testing.T) {

--- a/repr_test.go
+++ b/repr_test.go
@@ -80,10 +80,13 @@ func TestReprZeroSliceMapFields(t *testing.T) {
 		ZB  bool
 		B   bool
 		ZC  zeroTest
+		ZC2 zeroTest
 		C   zeroTest
 		T   *time.Time
-	}{[]string{}, []string{"a", "b"}, map[string]string{}, map[string]string{"a": "b"}, 0, 1, "", "a", false, true, zeroTest{i: 100}, zeroTest{i: 10}, nil}
-	equal(t, `struct { ZSl []string; Sl []string; ZM map[string]string; M map[string]string; ZI int; I int; ZS string; S string; ZB bool; B bool; ZC repr.zeroTest; C repr.zeroTest; T *time.Time }{ZSl: []string{}, Sl: []string{"a", "b"}, ZM: map[string]string{}, M: map[string]string{"a": "b"}, I: 1, S: "a", B: true, C: repr.zeroTest{i: 10}}`, String(v, OmitEmpty(false), OmitZero(true)))
+		ZIf isZeroer
+		If  isZeroer
+	}{[]string{}, []string{"a", "b"}, map[string]string{}, map[string]string{"a": "b"}, 0, 1, "", "a", false, true, zeroTest{i: 100}, zeroTest{i: 0}, zeroTest{i: 10}, nil, nil, (*time.Time)(nil)}
+	equal(t, `struct { ZSl []string; Sl []string; ZM map[string]string; M map[string]string; ZI int; I int; ZS string; S string; ZB bool; B bool; ZC repr.zeroTest; ZC2 repr.zeroTest; C repr.zeroTest; T *time.Time; ZIf repr.isZeroer; If repr.isZeroer }{ZSl: []string{}, Sl: []string{"a", "b"}, ZM: map[string]string{}, M: map[string]string{"a": "b"}, I: 1, S: "a", B: true, ZC2: repr.zeroTest{}, C: repr.zeroTest{i: 10}, If: nil}`, String(v, OmitEmpty(false), OmitZero(true)))
 }
 
 func TestReprStringArray(t *testing.T) {


### PR DESCRIPTION
I found another couple of `IsZero()` edge cases. This PR adds tests and the associated fixes.